### PR TITLE
Switch to Python 3

### DIFF
--- a/ctn_waterloo/filters.py
+++ b/ctn_waterloo/filters.py
@@ -34,7 +34,7 @@ def nice_date(date_str):
 
 def slugify(value, separator='-'):
     """ Slugify a string, to make it URL friendly. """
-    if type(value) == unicode:
+    if type(value) == str:
         # Transform the string to NFKC before perfoming any operation on it.
         # This is important as e.g. umlauts have a distinct Unicode codepoint,
         # but may be represented as two Unicode codepoints in the input (e.g.
@@ -44,13 +44,13 @@ def slugify(value, separator='-'):
 
         # Implement proper transliteration of German umlauts.
         replacement_dict = ({
-            unichr(0xE4): "ae",
-            unichr(0xF6): "oe",
-            unichr(0xFC): "ue",
-            unichr(0xC4): "Ae",
-            unichr(0xD6): "Oe",
-            unichr(0xDC): "Ue",
-            unichr(0xDF): "ss",
+            chr(0xE4): "ae",
+            chr(0xF6): "oe",
+            chr(0xFC): "ue",
+            chr(0xC4): "Ae",
+            chr(0xD6): "Oe",
+            chr(0xDC): "Ue",
+            chr(0xDF): "ss",
         })
         for src, tar in replacement_dict.items():
             value = value.replace(src, tar)

--- a/ctn_waterloo/manage.py
+++ b/ctn_waterloo/manage.py
@@ -17,8 +17,12 @@ def freeze(serve=False):
     if serve:
         freezer.run(debug=True)
     else:
-        urls = freezer.freeze()
-        print('Built %i files.' % len(urls))
+        print("Writing files to {}".format(freezer.root))
+        n_urls = 0
+        for entity in freezer.freeze_yield():
+            n_urls += 1
+            print("Processing {}".format(entity.url))
+        print('Done. Built {} files.'.format(n_urls))
 
 
 @manager.command

--- a/ctn_waterloo/model.py
+++ b/ctn_waterloo/model.py
@@ -66,9 +66,9 @@ class Model(object):
         return people
 
     def publication(self, pub):
-        if pub.meta.has_key('url'):
+        if 'url' in pub.meta:
             pub.fulltext = pub['url']
-        if pub['cite_info'].has_key('journal'):
+        if 'journal' in pub['cite_info']:
             pub.journal = pub['cite_info']['journal']
         elif pub['type'] == 'techreport':
             pub.journal = "Tech Report"
@@ -82,7 +82,7 @@ class Model(object):
                     pub.journal = "PhD Thesis"
         elif 'book' in pub['type']:
             pub.journal = pub['cite_info']['publisher']
-        elif pub['cite_info'].has_key('booktitle'):
+        elif 'booktitle' in pub['cite_info']:
             pub.journal = pub['cite_info']['booktitle']
 
         pub.authors = [self.authorlink(name) for name in pub['authors']]

--- a/ctn_waterloo/templates/publications_page.html
+++ b/ctn_waterloo/templates/publications_page.html
@@ -45,7 +45,7 @@
     <div class="span3">
       <h4>{{ publication.type }}</h4>
       <dl>
-        {% for key, val in publication.cite_info.iteritems() %}
+        {% for key, val in publication.cite_info.items() %}
           <dt>{{ key.capitalize() }}</dt>
           <dd>{{ val }}</dd>
         {% endfor %}

--- a/manage.py
+++ b/manage.py
@@ -1,3 +1,3 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from ctn_waterloo.manage import manager
 manager.run()


### PR DESCRIPTION
This is the first PR in a series in preparation to switching to a new self-hosted CI system.

This PR switches the code base to Python 3, mostly following `2to3`s suggestions. Note that the scripts will no longer run with Python 2, so this PR should only be merged when we finally switch to our new infrastructure.

This closes #46 