### PR TITLE
changing @proceedings to @inproceedings

### DIFF
--- a/ctn_waterloo/content/publications/bekolay2011.bib
+++ b/ctn_waterloo/content/publications/bekolay2011.bib
@@ -1,4 +1,4 @@
-@proceedings {bekolay2011,
+@inproceedings {bekolay2011,
   title = {A general error-modulated STDP learning rule applied to reinforcement learning in the basal ganglia},
   journal = {Cognitive and Systems Neuroscience},
   year = {2011},

--- a/ctn_waterloo/content/publications/bobier2010.bib
+++ b/ctn_waterloo/content/publications/bobier2010.bib
@@ -1,4 +1,4 @@
-@proceedings {bobier2010,
+@inproceedings {bobier2010,
   title = {Dynamic Routing Model for Visuospatial Attention},
   journal = {Cognitive and Systems Neuroscience},
   year = {2010},

--- a/ctn_waterloo/content/publications/bobier2011.bib
+++ b/ctn_waterloo/content/publications/bobier2011.bib
@@ -1,4 +1,4 @@
-@proceedings {bobier2011,
+@inproceedings {bobier2011,
   title = {The attentional routing circuit: receptive field modulation through nonlinear dendritic interactions},
   journal = {Cognitive and Systems Neuroscience},
   year = {2011},

--- a/ctn_waterloo/content/publications/carrillo2009.bib
+++ b/ctn_waterloo/content/publications/carrillo2009.bib
@@ -1,4 +1,4 @@
-@proceedings {carrillo2009,
+@inproceedings {carrillo2009,
   title = {Combining Text Vector Representations for Information Retrieval},
   journal = {Proceedings of the 12th International Conference on Text, Speech and Dialogue},
   year = {2009},

--- a/ctn_waterloo/content/publications/carrillo2009a.bib
+++ b/ctn_waterloo/content/publications/carrillo2009a.bib
@@ -1,4 +1,4 @@
-@proceedings {carrillo2009a,
+@inproceedings {carrillo2009a,
   title = {Concept representations in Geographic Information Retrieval as Re-ranking Strategies},
   journal = {18th ACM Conference on Information and Knowledge Management},
   year = {2009},

--- a/ctn_waterloo/content/publications/carrillo2010.bib
+++ b/ctn_waterloo/content/publications/carrillo2010.bib
@@ -1,4 +1,4 @@
-@proceedings {carrillo2010,
+@inproceedings {carrillo2010,
   title = {Concept Based Representations for Ranking in Geographic Information Retrieval},
   journal = {IceTAL 2010},
   year = {2010},

--- a/ctn_waterloo/content/publications/choo2010a.bib
+++ b/ctn_waterloo/content/publications/choo2010a.bib
@@ -1,4 +1,4 @@
-@proceedings {choo2010a,
+@inproceedings {choo2010a,
   title = {A Spiking Neuron Model of Serial-Order Recall},
   journal = {32nd Annual Conference of the Cognitive Science Society},
   year = {2010},

--- a/ctn_waterloo/content/publications/choudhary2012.bib
+++ b/ctn_waterloo/content/publications/choudhary2012.bib
@@ -1,4 +1,4 @@
-@proceedings {choudhary2012,
+@inproceedings {choudhary2012,
   title = {Silicon Neurons that Compute},
   journal = {International Conference on Artificial Neural Networks},
   volume = {7552},

--- a/ctn_waterloo/content/publications/dethier2011.bib
+++ b/ctn_waterloo/content/publications/dethier2011.bib
@@ -1,4 +1,4 @@
-@proceedings {dethier2011,
+@inproceedings {dethier2011,
   title = {A Brain-Machine Interface Operating with a Real-Time Spiking Neural Network Control Algorithm},
   journal = {Neural Information Processing Systems (NIPS) 24},
   year = {2011},

--- a/ctn_waterloo/content/publications/dewolf2010b.bib
+++ b/ctn_waterloo/content/publications/dewolf2010b.bib
@@ -1,4 +1,4 @@
-@proceedings {dewolf2010b,
+@inproceedings {dewolf2010b,
   title = {NOCH: A framework for biologically plausible models of neural motor control},
   journal = {20th Annual Neural Control of Movement Conference},
   year = {2010},

--- a/ctn_waterloo/content/publications/dewolf2011a.bib
+++ b/ctn_waterloo/content/publications/dewolf2011a.bib
@@ -1,4 +1,4 @@
-@proceedings {dewolf2011a,
+@inproceedings {dewolf2011a,
   title = {A spiking neuron model of movement and pre-movement activity in M1},
   journal = {Cognitive and Systems Neuroscience},
   year = {2011},

--- a/ctn_waterloo/content/publications/eliasmith2004.bib
+++ b/ctn_waterloo/content/publications/eliasmith2004.bib
@@ -1,4 +1,4 @@
-@proceedings {eliasmith2004,
+@inproceedings {eliasmith2004,
   title = {Learning context sensitive logical inference in a neurobiological simulation},
   journal = {AAAI Fall Symposium: Compositional Connectionism in Cognitive Science},
   year = {2004},

--- a/ctn_waterloo/content/publications/eliasmith2005.bib
+++ b/ctn_waterloo/content/publications/eliasmith2005.bib
@@ -1,4 +1,4 @@
-@proceedings {eliasmith2005,
+@inproceedings {eliasmith2005,
   title = {Cognition with neurons: A large-scale, biologically realistic model of the Wason task},
   journal = {27th Annual Meeting of the Cognitive Science Society},
   year = {2005},

--- a/ctn_waterloo/content/publications/eliasmith2012a.bib
+++ b/ctn_waterloo/content/publications/eliasmith2012a.bib
@@ -1,4 +1,4 @@
-@proceedings {eliasmith2012a,
+@inproceedings {eliasmith2012a,
   title = {Nengo and the Neural Engineering Framework: From Spikes to Cognition},
   journal = {Cognitive Science Society},
   year = {2012},

--- a/ctn_waterloo/content/publications/elliott2009.bib
+++ b/ctn_waterloo/content/publications/elliott2009.bib
@@ -1,4 +1,4 @@
-@proceedings {elliott2009,
+@inproceedings {elliott2009,
   title = {MCMC with spiking neurons},
   journal = {NIPS Workshop on Bayesian Inference in the Brain},
   year = {2009},

--- a/ctn_waterloo/content/publications/fishbein2008.bib
+++ b/ctn_waterloo/content/publications/fishbein2008.bib
@@ -1,4 +1,4 @@
-@proceedings {fishbein2008,
+@inproceedings {fishbein2008,
   title = {Integrating structure and meaning: A new method for encoding structure for text classification},
   journal = {Advances in Information Retrieval},
   year = {2008},

--- a/ctn_waterloo/content/publications/fishbein2008a.bib
+++ b/ctn_waterloo/content/publications/fishbein2008a.bib
@@ -1,4 +1,4 @@
-@proceedings {fishbein2008a,
+@inproceedings {fishbein2008a,
   title = {Methods for augmenting semantic models with structural information for text classification},
   journal = {Advances in Information Retrieval},
   year = {2008},

--- a/ctn_waterloo/content/publications/galluppi2012.bib
+++ b/ctn_waterloo/content/publications/galluppi2012.bib
@@ -1,4 +1,4 @@
-@proceedings {galluppi2012,
+@inproceedings {galluppi2012,
   title = {Real Time On-Chip Implementation of Dynamical Systems with Spiking Neurons},
   journal = {IJCNN},
   year = {2012},

--- a/ctn_waterloo/content/publications/rasmussen2010.bib
+++ b/ctn_waterloo/content/publications/rasmussen2010.bib
@@ -1,4 +1,4 @@
-@proceedings {rasmussen2010,
+@inproceedings {rasmussen2010,
   title = {A neural model of rule generation in inductive reasoning},
   journal = {32nd Annual Conference of the Cognitive Science Society},
   year = {2010},

--- a/ctn_waterloo/content/publications/singh2004.bib
+++ b/ctn_waterloo/content/publications/singh2004.bib
@@ -1,4 +1,4 @@
-@proceedings {singh2004,
+@inproceedings {singh2004,
   title = {A dynamic model of working memory in the PFC during a somatosensory discrimination task},
   journal = {Computational and Systems Neuroscience},
   year = {2004},

--- a/ctn_waterloo/content/publications/stewart2009.bib
+++ b/ctn_waterloo/content/publications/stewart2009.bib
@@ -1,4 +1,4 @@
-@proceedings {stewart2009,
+@inproceedings {stewart2009,
   title = {A biologically realistic cleanup memory: Autoassociation in spiking neurons},
   journal = {9th International Conference on Cognitive Modelling},
   year = {2009},

--- a/ctn_waterloo/content/publications/stewart2009b.bib
+++ b/ctn_waterloo/content/publications/stewart2009b.bib
@@ -1,4 +1,4 @@
-@proceedings {stewart2009b,
+@inproceedings {stewart2009b,
   title = {Spiking neurons and central executive control: The origin of the 50-millisecond cognitive cycle},
   journal = {9th International Conference on Cognitive Modelling},
   year = {2009},

--- a/ctn_waterloo/content/publications/stewart2009c.bib
+++ b/ctn_waterloo/content/publications/stewart2009c.bib
@@ -1,4 +1,4 @@
-@proceedings {stewart2009c,
+@inproceedings {stewart2009c,
   title = {Building production systems with realistic spiking neurons},
   journal = {Cognitive Science Conference},
   year = {2008},

--- a/ctn_waterloo/content/publications/stewart2010.bib
+++ b/ctn_waterloo/content/publications/stewart2010.bib
@@ -1,4 +1,4 @@
-@proceedings {stewart2010,
+@inproceedings {stewart2010,
   title = {Dynamic Behaviour of a Spiking Model of Action Selection in the Basal Ganglia},
   journal = {10th International Conference on Cognitive Modeling},
   year = {2010},

--- a/ctn_waterloo/content/publications/stewart2011a.bib
+++ b/ctn_waterloo/content/publications/stewart2011a.bib
@@ -1,4 +1,4 @@
-@proceedings {stewart2011a,
+@inproceedings {stewart2011a,
   title = {Neural Cognitive Modelling: A Biologically Constrained Spiking Neuron Model of the Tower of Hanoi Task},
   journal = {33rd Annual Conference of the Cognitive Science Society},
   year = {2011},

--- a/ctn_waterloo/content/publications/stewart2012c.bib
+++ b/ctn_waterloo/content/publications/stewart2012c.bib
@@ -1,4 +1,4 @@
-@proceedings {stewart2012c,
+@inproceedings {stewart2012c,
   title = {Spaun: A Perception-Cognition-Action Model Using Spiking Neurons},
   journal = {Cognitive Science Society},
   booktitle = {Cognitive Science Society},

--- a/ctn_waterloo/content/publications/stewart2015.bib
+++ b/ctn_waterloo/content/publications/stewart2015.bib
@@ -1,4 +1,4 @@
-@proceedings {stewart2009,
+@inproceedings {stewart2009,
   title = {Explorations in Distributed Recurrent Biological Parsing},
   journal = {International Conference on Cognitive Modelling},
   year = {2015},

--- a/ctn_waterloo/content/publications/tang2010.bib
+++ b/ctn_waterloo/content/publications/tang2010.bib
@@ -1,4 +1,4 @@
-@proceedings {tang2010,
+@inproceedings {tang2010,
   title = {Deep networks for robust visual recognition},
   journal = {International Conference on Machine Learning},
   year = {2010},


### PR DESCRIPTION
Fixing the .bib of some publications so that latex interprets them as intended. Found out recently that the conference editor's name will be shown in the bibliography instead of the author if the editor field is filled in when just using proceedings, and that inproceedings is the correct type to use:
https://tex.stackexchange.com/questions/516802/what-are-differences-amongst-conference-proceedings-and-inproceedings